### PR TITLE
Fix branding.css to support PSOBA image

### DIFF
--- a/onebusaway-enterprise-sound-webapp/src/main/webapp/css/branding.css
+++ b/onebusaway-enterprise-sound-webapp/src/main/webapp/css/branding.css
@@ -243,11 +243,15 @@ html, body {
 #topbar #branding {
     float: left;
     height: 90px;
+    width: 325px;
 }
-#topbar #branding a img,
-#topbar #branding a {
-	border: none;
-	text-decoration: none;
+#topbar #branding a#agency-logo {
+    height: 90px;
+    background-image: url('img/agency_logo.png');
+    display: block;
+    background-repeat: no-repeat;
+    background-size: contain;
+    width: 100%;
 }
 #topbar #search {
     float: right;


### PR DESCRIPTION
This is a working fix for the broken horizontal tab bar for the HART and Sound Transit pages. This is a workaround to the issue in OTD-174

This pull request is in conjunction with
https://github.com/camsys/onebusaway-application-modules/pull/15
https://github.com/camsys/onebusaway-hart-enterprise/pull/1